### PR TITLE
Ensure reload is imported from importlib in Python > 3.4

### DIFF
--- a/sDNAProvider.py
+++ b/sDNAProvider.py
@@ -29,6 +29,10 @@ from processing.core.AlgorithmProvider import AlgorithmProvider
 from processing.core.ProcessingConfig import Setting, ProcessingConfig
 
 import os,sys
+try:
+	reload
+except NameError:
+    from importlib import reload 
 
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.parameters import *


### PR DESCRIPTION
Test if reload is in builtins by simply referring to the function in a try block.  If a NameError occurs, the except block imports reload from importlib.  Comments, docstring and test using doctest in the attachment.
[import_reload_if_req.zip](https://github.com/fiftysevendegreesofrad/sdna_qgis_plugin/files/8872583/import_reload_if_req.zip)
.